### PR TITLE
feat: dual input mode aerospace + karabiner F18 + sketchybar fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug
+description: Probleme avec une configuration
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description du probleme
+      description: Decris le bug rencontre
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportement attendu
+      description: Que devrait-il se passer ?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environnement
+      description: Version macOS, clavier, etc.
+      placeholder: |
+        - macOS: Tahoe 26.x
+        - Clavier: AZERTY ISO
+        - Interne / Externe
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Config concernee
+      options:
+        - aerospace
+        - sketchybar
+        - karabiner
+        - zed
+        - ghostty
+        - svim
+        - nix
+        - zsh
+        - tmux
+        - global
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Feature
+description: Nouvelle fonctionnalite ou amelioration de config
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Decris la fonctionnalite ou l'amelioration souhaitee
+    validations:
+      required: true
+  - type: textarea
+    id: configs
+    attributes:
+      label: Configs concernees
+      description: Quelles configs sont impactees ?
+      placeholder: |
+        - aerospace
+        - sketchybar
+        - karabiner
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - aerospace
+        - sketchybar
+        - karabiner
+        - zed
+        - ghostty
+        - svim
+        - nix
+        - zsh
+        - tmux
+        - global
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Resume
+
+<!-- Description courte des changements -->
+
+## Configs modifiees
+
+- [ ] aerospace
+- [ ] sketchybar
+- [ ] karabiner
+- [ ] zed
+- [ ] ghostty
+- [ ] svim
+- [ ] nix
+- [ ] zsh
+- [ ] tmux
+
+## Changements
+
+<!-- Liste des changements -->
+
+-
+
+## Tests
+
+- [ ] `chezmoi diff` verifie
+- [ ] `chezmoi apply --dry-run` sans erreur
+- [ ] Config testee localement
+- [ ] Pas de regression sur les autres configs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Branches
+
+```
+feature/<scope>-<description>   # nouvelle fonctionnalite
+fix/<scope>-<description>       # correction de bug
+docs/<description>              # documentation
+chore/<description>             # maintenance
+```
+
+## Commits
+
+Format : `<type>(<scope>): <description>`
+
+### Types
+
+| Type       | Usage                          |
+|------------|--------------------------------|
+| `feat`     | Nouvelle fonctionnalite        |
+| `fix`      | Correction de bug              |
+| `docs`     | Documentation                  |
+| `refactor` | Refactoring sans changement    |
+| `chore`    | Maintenance, nettoyage         |
+| `sync`     | Synchronisation configs locales|
+
+### Scopes
+
+`aerospace`, `sketchybar`, `karabiner`, `zed`, `ghostty`, `svim`, `nix`, `zsh`, `tmux`
+
+### Exemples
+
+```
+feat(aerospace): add aero mode with F18 leader key
+fix(sketchybar): fix bluetooth icon using nerd font
+docs: update README with new keybindings
+sync: update sketchybar and aerospace configs
+```
+
+## Workflow
+
+1. Creer une branche depuis `main`
+2. Sync les configs : `chezmoi add <fichier>`
+3. Commiter par scope (grouper les changements lies)
+4. Pousser et creer une PR
+5. Merge dans `main` apres review
+
+## Chezmoi
+
+```bash
+chezmoi add ~/.config/<app>/<file>    # ajouter un fichier
+chezmoi diff                          # voir les differences
+chezmoi apply --dry-run               # tester sans appliquer
+chezmoi apply                         # appliquer
+```

--- a/README.md
+++ b/README.md
@@ -313,61 +313,75 @@ Welcome to my dotfiles repository! This repository is managed using [Chezmoi](ht
 > Modern tiling window manager (no SIP required) - See [MIGRATION-YABAI-TO-AEROSPACE.md](./MIGRATION-YABAI-TO-AEROSPACE.md)
 
 > [!NOTE]
-> **Karabiner-Elements** maps the **right Option key** (`⌥→`) to `Ctrl+Alt`, which is the modifier used in AeroSpace bindings.
-> This preserves the left Option key for AZERTY special characters (`{ } [ ] @ # | \`).
-> In the tables below, <kbd>⌥→</kbd> represents physically pressing the **right Option key**.
+> **Dual input mode** pour clavier AZERTY - le left Option reste libre pour les caracteres speciaux (`{ } [ ] @ # | \`).
+>
+> | Mode | Methode | Usage |
+> |------|---------|-------|
+> | **Leader key** | <kbd>⌥→</kbd> (F18 via Karabiner) puis touche | Clavier interne (portable) |
+> | **Held modifier** | <kbd>⌥→</kbd> maintenu (Ctrl+Alt via Karabiner) puis touche | Clavier externe (desktop) |
+>
+> Sketchybar affiche un indicateur visuel du mode actif (aero/resize/service).
 
 ### Workspace Navigation
 
-| Shortcut | AeroSpace Binding | Workspace | Applications |
-|----------|-------------------|-----------|-------------|
-| <kbd>⌥→</kbd> + <kbd>1</kbd> | `ctrl-alt-1` | 1 - Home | Mail, Calendar, Canary Mail |
-| <kbd>⌥→</kbd> + <kbd>2</kbd> | `ctrl-alt-2` | 2 - Music | Apple Music, Spotify, Tidal |
-| <kbd>⌥→</kbd> + <kbd>3</kbd> | `ctrl-alt-3` | 3 - Development | Zed, Ghostty, VS Code, JetBrains, Postman |
-| <kbd>⌥→</kbd> + <kbd>Q</kbd> | `ctrl-alt-q` | 4 - Web | Helium, Dia/Arc, Chrome, Safari |
-| <kbd>⌥→</kbd> + <kbd>W</kbd> | `ctrl-alt-w` | 5 - Communication | Slack, Discord, Messages, Teams, Zoom |
-| <kbd>⌥→</kbd> + <kbd>E</kbd> | `ctrl-alt-e` | 6 - Server Tools | TablePlus, OrbStack, Docker |
-| <kbd>⌥→</kbd> + <kbd>O</kbd> | `ctrl-alt-o` | 7 - Notes | Obsidian |
-| <kbd>⌥→</kbd> + <kbd>C</kbd> | `ctrl-alt-c` | 8 - Claude AI | Claude |
-| <kbd>⌥→</kbd> + <kbd>Tab</kbd> | `ctrl-alt-tab` | Back and forth | Previous workspace |
+| Leader key | Held modifier | Workspace | Applications |
+|------------|---------------|-----------|-------------|
+| <kbd>⌥→</kbd> <kbd>1</kbd> | <kbd>⌥→</kbd>+<kbd>1</kbd> | 1 - Home | Mail, Calendar, Canary Mail |
+| <kbd>⌥→</kbd> <kbd>2</kbd> | <kbd>⌥→</kbd>+<kbd>2</kbd> | 2 - Music | Apple Music, Spotify, Tidal |
+| <kbd>⌥→</kbd> <kbd>3</kbd> | <kbd>⌥→</kbd>+<kbd>3</kbd> | 3 - Development | Zed, Ghostty, VS Code, JetBrains, Postman |
+| <kbd>⌥→</kbd> <kbd>Q</kbd> | <kbd>⌥→</kbd>+<kbd>Q</kbd> | 4 - Web | Helium, Dia/Arc, Chrome, Safari |
+| <kbd>⌥→</kbd> <kbd>W</kbd> | <kbd>⌥→</kbd>+<kbd>W</kbd> | 5 - Communication | Slack, Discord, Messages, Teams, Zoom |
+| <kbd>⌥→</kbd> <kbd>E</kbd> | <kbd>⌥→</kbd>+<kbd>E</kbd> | 6 - Server Tools | TablePlus, OrbStack, Docker |
+| <kbd>⌥→</kbd> <kbd>O</kbd> | <kbd>⌥→</kbd>+<kbd>O</kbd> | 7 - Notes | Obsidian |
+| <kbd>⌥→</kbd> <kbd>C</kbd> | <kbd>⌥→</kbd>+<kbd>C</kbd> | 8 - Claude AI | Claude |
+| <kbd>⌥→</kbd> <kbd>Tab</kbd> | <kbd>⌥→</kbd>+<kbd>Tab</kbd> | Back and forth | Previous workspace |
 
 ### Window Focus
 
-| Shortcut | AeroSpace Binding | Action |
-|----------|-------------------|--------|
-| <kbd>⌥→</kbd> + <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | `ctrl-alt-h/j/k/l` | Focus window (left/down/up/right) |
-| <kbd>⌥→</kbd> + <kbd>←</kbd>/<kbd>↓</kbd>/<kbd>↑</kbd>/<kbd>→</kbd> | `ctrl-alt-arrows` | Focus window (arrows) |
+| Leader key | Held modifier | Action |
+|------------|---------------|--------|
+| <kbd>⌥→</kbd> <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | <kbd>⌥→</kbd>+<kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | Focus window (vim-style) |
+| <kbd>⌥→</kbd> <kbd>←</kbd>/<kbd>↓</kbd>/<kbd>↑</kbd>/<kbd>→</kbd> | <kbd>⌥→</kbd>+<kbd>←</kbd>/<kbd>↓</kbd>/<kbd>↑</kbd>/<kbd>→</kbd> | Focus window (arrows) |
 
 ### Window Movement
 
-| Shortcut | AeroSpace Binding | Action |
-|----------|-------------------|--------|
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | `ctrl-alt-shift-h/j/k/l` | Move window (left/down/up/right) |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>←</kbd>/<kbd>↓</kbd>/<kbd>↑</kbd>/<kbd>→</kbd> | `ctrl-alt-shift-arrows` | Move window (arrows) |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> | `ctrl-alt-shift-1/2/3` | Move to workspace 1/2/3 |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>Q</kbd>/<kbd>W</kbd>/<kbd>E</kbd> | `ctrl-alt-shift-q/w/e` | Move to workspace 4/5/6 |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>O</kbd>/<kbd>C</kbd> | `ctrl-alt-shift-o/c` | Move to workspace 7/8 |
+| Leader key | Held modifier | Action |
+|------------|---------------|--------|
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>h</kbd>/<kbd>j</kbd>/<kbd>k</kbd>/<kbd>l</kbd> | Move window (vim-style) |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>1</kbd>-<kbd>3</kbd>/<kbd>Q</kbd>/<kbd>W</kbd>/<kbd>E</kbd>/<kbd>O</kbd>/<kbd>C</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>key</kbd> | Move to workspace |
 
 ### Layout & Display
 
-| Shortcut | AeroSpace Binding | Action |
-|----------|-------------------|--------|
-| <kbd>⌥→</kbd> + <kbd>/</kbd> | `ctrl-alt-slash` | Toggle tiles layout (horizontal/vertical) |
-| <kbd>⌥→</kbd> + <kbd>,</kbd> | `ctrl-alt-comma` | Toggle accordion layout (cascade) |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>Space</kbd> | `ctrl-alt-shift-space` | Toggle floating/tiling |
-| <kbd>⌥→</kbd> + <kbd>F</kbd> | `ctrl-alt-f` | Toggle fullscreen |
-| <kbd>⌥→</kbd> + <kbd>-</kbd>/<kbd>=</kbd> | `ctrl-alt-minus/equal` | Resize window (smart -50/+50) |
-| <kbd>⌥→</kbd> + <kbd>R</kbd> | `ctrl-alt-r` | Enter resize mode |
+| Leader key | Held modifier | Action |
+|------------|---------------|--------|
+| <kbd>⌥→</kbd> <kbd>/</kbd> | <kbd>⌥→</kbd>+<kbd>/</kbd> | Toggle tiles layout |
+| <kbd>⌥→</kbd> <kbd>,</kbd> | <kbd>⌥→</kbd>+<kbd>,</kbd> | Toggle accordion layout |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>Space</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>Space</kbd> | Toggle floating/tiling |
+| <kbd>⌥→</kbd> <kbd>F</kbd> | <kbd>⌥→</kbd>+<kbd>F</kbd> | Toggle fullscreen |
+| <kbd>⌥→</kbd> <kbd>-</kbd>/<kbd>=</kbd> | <kbd>⌥→</kbd>+<kbd>-</kbd>/<kbd>=</kbd> | Resize window (smart) |
+| <kbd>⌥→</kbd> <kbd>R</kbd> | <kbd>⌥→</kbd>+<kbd>R</kbd> | Enter resize mode |
 
 ### Utilities
 
-| Shortcut | AeroSpace Binding | Action |
-|----------|-------------------|--------|
-| <kbd>⌥→</kbd> + <kbd>Enter</kbd> | `ctrl-alt-enter` | Open Ghostty terminal |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>X</kbd> | `ctrl-alt-shift-x` | Close window |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>=</kbd> | `ctrl-alt-shift-equal` | Balance window sizes |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>R</kbd> | `ctrl-alt-shift-r` | Reload AeroSpace config |
-| <kbd>⌥→</kbd> + <kbd>⇧</kbd> + <kbd>;</kbd> | `ctrl-alt-shift-semicolon` | Enter service mode |
+| Leader key | Held modifier | Action |
+|------------|---------------|--------|
+| <kbd>⌥→</kbd> <kbd>Enter</kbd> | <kbd>⌥→</kbd>+<kbd>Enter</kbd> | Open Ghostty terminal |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>X</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>X</kbd> | Close window |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>=</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>=</kbd> | Balance window sizes |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>R</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>R</kbd> | Reload config |
+| <kbd>⌥→</kbd> <kbd>⇧</kbd>+<kbd>;</kbd> | <kbd>⌥→</kbd>+<kbd>⇧</kbd>+<kbd>;</kbd> | Enter service mode |
+| <kbd>Esc</kbd> | <kbd>Esc</kbd> | Exit current mode |
+
+### SketchyVim (svim)
+
+> Ajoute les modes vim (Normal/Insert/Visual) a tous les champs texte macOS via l'API Accessibility.
+> Indicateur de mode visible dans Sketchybar.
+
+| Config | Description |
+|--------|-------------|
+| `~/.config/svim/svimrc` | Remaps vim (Y, H, L) |
+| `~/.config/svim/blacklist` | Apps exclues (Ghostty, Zed, terminals) |
+| `~/.config/svim/svim.sh` | Hook sketchybar pour indicateur de mode |
 
 ## Shortcuts & Keybindings ⌨️
 

--- a/dot_config/aerospace/aerospace.toml
+++ b/dot_config/aerospace/aerospace.toml
@@ -1,11 +1,16 @@
 # ╭─────────────────────────────────────────────────────────────╮
 # │                    AeroSpace Configuration                  │
 # │              Configuration Workflow Développeur             │
-# │                   Alt Droite Exclusif                       │
+# │           Alt Droite via hidutil + Mode Leader              │
 # ╰─────────────────────────────────────────────────────────────╯
 
 # Place ce fichier dans ~/.config/aerospace/aerospace.toml
-# Configuration optimisée pour workflow de développement avec 6 workspaces spécialisés
+# Configuration optimisée pour workflow de développement avec 8 workspaces spécialisés
+#
+# SETUP (sans Karabiner - workaround bug macOS Tahoe 26.4 beta) :
+#   hidutil remappe right_option → F18 (LaunchAgent: com.local.hidutil-remap)
+#   F18 sert de "leader key" pour entrer en mode aero
+#   Les bindings ctrl-alt sont gardés en fallback (clavier externe + Karabiner)
 
 # ═══════════════════════════════════════════════════════════════
 # PARAMÈTRES GÉNÉRAUX
@@ -66,20 +71,25 @@ after-startup-command = [
 [key-mapping]
 preset = 'qwerty'
 
-# IMPORTANT: Configuration AZERTY avec Alt droite EXCLUSIF
-# 
+# IMPORTANT: Configuration AZERTY avec Alt gauche préservé
+#
 # AeroSpace ne supporte que qwerty/dvorak/colemak (pas azerty natif)
-# Sur AZERTY, Alt gauche (AltGr) est ESSENTIEL pour : { } [ ] @ # | \ etc.
-# Il faut garder Alt gauche pour le code mais désactiver UNIQUEMENT pour AeroSpace !
+# Sur AZERTY, Alt gauche est ESSENTIEL pour : { } [ ] @ # | \ etc.
 #
-# SOLUTION KARABINER-ELEMENTS (obligatoire pour AZERTY) :
-# 1. Installer: brew install --cask karabiner-elements
-# 2. Importer le fichier: ~/.config/karabiner/aerospace-azerty.json
-# 3. Activer les règles dans Karabiner-Elements > Complex Modifications
-# 4. Cela bloque Alt gauche UNIQUEMENT pour les raccourcis AeroSpace
-# 5. Alt gauche reste fonctionnel pour tous les caractères spéciaux AZERTY
+# IMPORTANT: Configuration AZERTY avec Alt droite EXCLUSIF
 #
-# Résultat: Alt DROITE = AeroSpace, Alt GAUCHE = caractères spéciaux
+# AeroSpace ne supporte que qwerty/dvorak/colemak (pas azerty natif)
+# Sur AZERTY, Alt gauche est ESSENTIEL pour : { } [ ] @ # | \ etc.
+#
+# SOLUTION ACTUELLE (hidutil - sans Karabiner) :
+#   hidutil remappe right_option → F18 (persistant via LaunchAgent)
+#   F18 = leader key → entre en mode "aero"
+#   Appui right_option puis touche = action AeroSpace
+#   Alt gauche reste 100% libre pour les caractères spéciaux AZERTY
+#
+# FALLBACK (clavier externe au taf si Karabiner fonctionne) :
+#   Les bindings ctrl-alt-* restent actifs en mode main
+#   Karabiner remappe right_option → ctrl+alt sur clavier externe
 
 # ═══════════════════════════════════════════════════════════════
 # ESPACES ENTRE FENÊTRES
@@ -100,8 +110,11 @@ outer.right = 8
 
 [mode.main.binding]
 
+# Leader key : right_option (remappee en F18 via hidutil)
+f18 = ['mode aero', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=aero']
+
 # ┌─────────────────────────────────────────────────────────────┐
-# │                    NAVIGATION WORKSPACES                    │
+# │              FALLBACK ctrl-alt (clavier externe)            │
 # └─────────────────────────────────────────────────────────────┘
 
 # Workspaces optimisés AZERTY (préserve { } [ ] | \ @ ` pour le code)
@@ -188,15 +201,15 @@ ctrl-alt-f = 'fullscreen'
 ctrl-alt-minus = 'resize smart -50'
 ctrl-alt-equal = 'resize smart +50'
 
-# Mode resize dédié
-ctrl-alt-r = 'mode resize'
+# Mode resize dedie
+ctrl-alt-r = ['mode resize', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=resize']
 
 # ┌─────────────────────────────────────────────────────────────┐
 # │                       UTILITAIRES                           │
 # └─────────────────────────────────────────────────────────────┘
 
-# Mode service pour actions avancées
-ctrl-alt-shift-semicolon = 'mode service'
+# Mode service pour actions avancees
+ctrl-alt-shift-semicolon = ['mode service', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=service']
 
 # Reload config
 ctrl-alt-shift-r = 'reload-config'
@@ -211,46 +224,144 @@ ctrl-alt-shift-equal = 'balance-sizes'
 ctrl-alt-enter = 'exec-and-forget open -a Ghostty'
 
 # ═══════════════════════════════════════════════════════════════
+# MODE AERO (Leader Key = right_option → F18)
+# ═══════════════════════════════════════════════════════════════
+# Appuyer right_option → entre ici → taper une touche → retour auto en main
+
+[mode.aero.binding]
+
+# Annuler
+esc = ['exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                    NAVIGATION WORKSPACES                    │
+# └─────────────────────────────────────────────────────────────┘
+
+1 = ['workspace 1', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=1', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+2 = ['workspace 2', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=2', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+3 = ['workspace 3', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=3', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+q = ['workspace 4', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=4', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+w = ['workspace 5', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=5', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+e = ['workspace 6', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=6', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+o = ['workspace 7', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=7', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+c = ['workspace 8', 'exec-and-forget sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=8', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# Navigation rapide
+tab = ['workspace-back-and-forth', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                   DÉPLACER VERS WORKSPACES                  │
+# └─────────────────────────────────────────────────────────────┘
+
+shift-1 = ['move-node-to-workspace 1', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-2 = ['move-node-to-workspace 2', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-3 = ['move-node-to-workspace 3', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-q = ['move-node-to-workspace 4', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-w = ['move-node-to-workspace 5', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-e = ['move-node-to-workspace 6', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-o = ['move-node-to-workspace 7', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-c = ['move-node-to-workspace 8', 'exec-and-forget sketchybar --trigger aerospace_workspace_change', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                      FOCUS FENÊTRES                         │
+# └─────────────────────────────────────────────────────────────┘
+
+# vim-style
+h = ['focus left', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+j = ['focus down', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+k = ['focus up', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+l = ['focus right', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# fleches
+left = ['focus left', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+down = ['focus down', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+up = ['focus up', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+right = ['focus right', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                    DÉPLACER FENÊTRES                        │
+# └─────────────────────────────────────────────────────────────┘
+
+# vim-style
+shift-h = ['move left', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-j = ['move down', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-k = ['move up', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-l = ['move right', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# fleches
+shift-left = ['move left', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-down = ['move down', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-up = ['move up', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-right = ['move right', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                       LAYOUTS                               │
+# └─────────────────────────────────────────────────────────────┘
+
+slash = ['layout tiles horizontal vertical', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+comma = ['layout accordion horizontal vertical', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-space = ['layout floating tiling', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+f = ['fullscreen', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                      REDIMENSIONNER                         │
+# └─────────────────────────────────────────────────────────────┘
+
+minus = ['resize smart -50', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+equal = ['resize smart +50', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+r = ['exec-and-forget sketchybar --trigger aerospace_mode_change MODE=resize', 'mode resize']
+
+# ┌─────────────────────────────────────────────────────────────┐
+# │                       UTILITAIRES                           │
+# └─────────────────────────────────────────────────────────────┘
+
+shift-semicolon = ['exec-and-forget sketchybar --trigger aerospace_mode_change MODE=service', 'mode service']
+shift-r = ['reload-config', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-x = ['close', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+shift-equal = ['balance-sizes', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+enter = ['exec-and-forget open -a Ghostty', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+
+# ═══════════════════════════════════════════════════════════════
 # MODE SERVICE (Actions Avancées)
 # ═══════════════════════════════════════════════════════════════
 
 [mode.service.binding]
 # Sortir du mode service
-esc = ['reload-config', 'mode main']
+esc = ['reload-config', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # Reset layout
-r = ['flatten-workspace-tree', 'mode main']
+r = ['flatten-workspace-tree', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # Toggle floating/tiling
-f = ['layout floating tiling', 'mode main']
+f = ['layout floating tiling', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # Fermer toutes les autres fenêtres
-backspace = ['close-all-windows-but-current', 'mode main']
+backspace = ['close-all-windows-but-current', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
-# Layouts spécialisés
-h = ['layout tiles horizontal', 'mode main']    # Horizontal split
-v = ['layout tiles vertical', 'mode main']      # Vertical split
-s = ['layout accordion vertical', 'mode main']  # Stack (cascade vertical)
-w = ['layout accordion horizontal', 'mode main'] # Wide tabs (cascade horizontal)
-t = ['layout tiles', 'mode main']               # Tiles auto
+# Layouts specialises
+h = ['layout tiles horizontal', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+v = ['layout tiles vertical', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+s = ['layout accordion vertical', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+w = ['layout accordion horizontal', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+t = ['layout tiles', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # Join containers
-ctrl-alt-shift-h = ['join-with left', 'mode main']
-ctrl-alt-shift-j = ['join-with down', 'mode main']
-ctrl-alt-shift-k = ['join-with up', 'mode main']
-ctrl-alt-shift-l = ['join-with right', 'mode main']
+ctrl-alt-shift-h = ['join-with left', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+ctrl-alt-shift-j = ['join-with down', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+ctrl-alt-shift-k = ['join-with up', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+ctrl-alt-shift-l = ['join-with right', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
-# Contrôle volume (bonus)
+# Controle volume (bonus)
 down = 'volume down'
 up = 'volume up'
-shift-down = ['volume set 0', 'mode main']
+shift-down = ['volume set 0', 'exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # ═══════════════════════════════════════════════════════════════
 # MODE RESIZE
 # ═══════════════════════════════════════════════════════════════
 
 [mode.resize.binding]
-# Navigation pour resize
+# Navigation pour resize (pas de retour auto, on reste en mode resize)
 h = 'resize width -50'
 j = 'resize height +50'
 k = 'resize height -50'
@@ -269,8 +380,8 @@ shift-minus = 'resize smart -10'
 shift-equal = 'resize smart +10'
 
 # Sortir du mode resize
-enter = 'mode main'
-esc = 'mode main'
+enter = ['exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
+esc = ['exec-and-forget sketchybar --trigger aerospace_mode_change MODE=main', 'mode main']
 
 # ═══════════════════════════════════════════════════════════════
 # RÈGLES AUTOMATIQUES PAR APPLICATION

--- a/dot_config/private_karabiner/private_karabiner.json
+++ b/dot_config/private_karabiner/private_karabiner.json
@@ -1,40 +1,47 @@
 {
-  "global": {
-    "check_for_updates_on_startup": true,
-    "show_in_menu_bar": true,
-    "show_profile_name_in_menu_bar": false
-  },
-  "profiles": [
-    {
-      "name": "Default",
-      "complex_modifications": {
-        "rules": [
-          {
-            "description": "Right Option to Ctrl+Alt",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "right_option"
-                },
-                "to": [
-                  {
-                    "key_code": "left_control",
-                    "modifiers": ["left_option"]
-                  }
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Right Option to Ctrl+Alt",
+                        "enabled": false,
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "right_option",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_control",
+                                        "modifiers": ["left_option"]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Right Option → F18 (AeroSpace leader key)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "right_option",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "to": [{ "key_code": "f18" }],
+                                "type": "basic"
+                            }
+                        ]
+                    }
                 ]
-              }
-            ]
-          }
-        ]
-      },
-      "devices": [],
-      "fn_function_keys": [],
-      "simple_modifications": [],
-      "virtual_hid_keyboard": {
-        "country_code": 0,
-        "keyboard_type_v2": "ansi"
-      }
-    }
-  ]
+            },
+            "name": "Default",
+            "virtual_hid_keyboard": {
+                "country_code": 1,
+                "keyboard_type_v2": "iso"
+            }
+        }
+    ]
 }

--- a/dot_config/sketchybar/executable_sketchybarrc
+++ b/dot_config/sketchybar/executable_sketchybarrc
@@ -83,6 +83,7 @@ sketchybar --add item aerospace_separator left \
              label.drawing=off
 
 source "$PLUGIN_DIR/front_app.sh"
+source "$PLUGIN_DIR/svim/item.sh"
 
 # Start AeroSpace mode monitor in background
 "$PLUGIN_DIR/aerospace/mode_trigger.sh" > /dev/null 2>&1 &

--- a/dot_config/sketchybar/plugins/aerospace/executable_item.sh
+++ b/dot_config/sketchybar/plugins/aerospace/executable_item.sh
@@ -2,6 +2,7 @@
 
 # ════════════════════════════════════════════════════════════════════
 # AeroSpace Config Switcher Item
+# -- Claude Dark theme (Zed port style) --
 # ════════════════════════════════════════════════════════════════════
 
 source "$HOME/.config/sketchybar/settings/settings.sh"
@@ -11,7 +12,8 @@ source "$SETTINGS_DIR/icons.sh"
 aerospace_switcher=(
   icon=$MACBOOK
   icon.font="SF Pro:Bold:16.0"
-  icon.color=$ICON_COLOR
+  icon.color=$GREY
+  icon.highlight_color=$ORANGE
   icon.padding_left=3
   icon.padding_right=3
 
@@ -31,3 +33,23 @@ sketchybar --add item aerospace_switcher left \
            --set aerospace_switcher "${aerospace_switcher[@]}" \
            --subscribe aerospace_switcher \
              mouse.clicked
+
+# ════════════════════════════════════════════════════════════════════
+# AeroSpace Mode Indicator
+# Affiche un badge (A/R/S) quand un mode non-main est actif
+# ════════════════════════════════════════════════════════════════════
+
+sketchybar --add item aerospace_mode left \
+           --set aerospace_mode \
+             updates=on \
+             drawing=off \
+             icon.font="$FONT:Bold:20.0" \
+             icon.padding_left=3 \
+             icon.padding_right=3 \
+             label.drawing=off \
+             background.drawing=off \
+             padding_left=3 \
+             padding_right=0 \
+             script="$PLUGIN_DIR/aerospace/mode.sh" \
+           --subscribe aerospace_mode \
+             aerospace_mode_change

--- a/dot_config/sketchybar/plugins/aerospace/executable_mode.sh
+++ b/dot_config/sketchybar/plugins/aerospace/executable_mode.sh
@@ -1,45 +1,30 @@
 #!/bin/bash
-
-source "$HOME/.config/sketchybar/settings/colors.sh"
-
-# Couleurs par mode
-MODE_COLORS=(
-  ["resize"]="0xffff6b35"    # Orange
-  ["service"]="0xff00d084"   # Vert
-)
+source "$HOME/.config/sketchybar/settings/settings.sh"
+source "$SETTINGS_DIR/colors.sh"
+source "$SETTINGS_DIR/icons.sh"
 
 update() {
-  # Récupérer le mode actuel d'AeroSpace
-  CURRENT_MODE=$(aerospace list-modes 2>/dev/null | grep -v "^main$" | head -1)
+  MODE="${MODE:-main}"
 
-  # Si aucun mode ou mode main, ne rien afficher
-  if [ -z "$CURRENT_MODE" ] || [ "$CURRENT_MODE" = "main" ]; then
-    sketchybar --set "$NAME" \
-               label="" \
-               drawing=off
-    exit 0
+  if [ "$MODE" = "main" ]; then
+    sketchybar --set "$NAME" drawing=off
+    return
   fi
 
-  # Première lettre en majuscule
-  MODE_LETTER=$(echo "${CURRENT_MODE:0:1}" | tr '[:lower:]' '[:upper:]')
+  DRAWING=on
+  case "$MODE" in
+    aero)    ICON="$AERO_NORMAL"  COLOR=$BLUE ;;
+    resize)  ICON="$AERO_RESIZE"  COLOR=$ORANGE ;;
+    service) ICON="$AERO_SERVICE" COLOR=$GREEN ;;
+    *)       ICON="$MODE_PENDING" COLOR=$MAGENTA ;;
+  esac
 
-  # Couleur du mode
-  MODE_COLOR="${MODE_COLORS[$CURRENT_MODE]}"
-  if [ -z "$MODE_COLOR" ]; then
-    MODE_COLOR="0xffb362ff"  # Violet par défaut
-  fi
-
-  # Afficher le mode
   sketchybar --set "$NAME" \
-             label="$MODE_LETTER" \
-             label.color="$WHITE" \
-             label.font="$FONT:Black:14.0" \
-             background.color="$MODE_COLOR" \
-             background.corner_radius=6 \
-             background.height=24 \
-             background.padding_left=8 \
-             background.padding_right=8 \
-             drawing=on
+    drawing=on \
+    icon="$ICON" \
+    icon.drawing=on \
+    icon.color="$COLOR" \
+    label.drawing=off
 }
 
 case "$SENDER" in

--- a/dot_config/sketchybar/plugins/bluetooth/executable_bluetooth.sh
+++ b/dot_config/sketchybar/plugins/bluetooth/executable_bluetooth.sh
@@ -3,11 +3,16 @@ source "$HOME/.config/sketchybar/settings/settings.sh"
 source "$SETTINGS_DIR/colors.sh"
 source "$SETTINGS_DIR/icons.sh"
 
+NERD="Liga SFMono Nerd Font"
+BT_ON="󰂯"
+BT_OFF="󰂲"
+
 update() {
-  # Vérifier si blueutil est installé
+  # Verifier si blueutil est installe
   if ! command -v blueutil &> /dev/null; then
     sketchybar --set bluetooth \
-      icon="$BLUETOOTH_OFF" \
+      icon="$BT_OFF" \
+      icon.font="$NERD:Bold:16.0" \
       icon.color=$RED \
       label.drawing=off \
       drawing=off
@@ -18,30 +23,29 @@ update() {
   BLUETOOTH_STATUS=$(blueutil --power)
 
   if [ "$BLUETOOTH_STATUS" = "1" ]; then
-    # Bluetooth activé
     CONNECTED_DEVICES=$(blueutil --connected 2>/dev/null)
     DEVICE_COUNT=$(echo "$CONNECTED_DEVICES" | grep -c "address:" 2>/dev/null || echo "0")
 
     if [ "$DEVICE_COUNT" -gt 0 ]; then
-      # Appareils connectés - icône bleue avec count
       sketchybar --set bluetooth \
-        icon="$BLUETOOTH" \
-        icon.color=$BLUE \
+        icon="$BT_ON" \
+        icon.font="$NERD:Bold:16.0" \
+        icon.color=$ORANGE \
         label="$DEVICE_COUNT" \
         label.drawing=on \
         drawing=on
     else
-      # Bluetooth activé mais aucun appareil connecté
       sketchybar --set bluetooth \
-        icon="$BLUETOOTH" \
+        icon="$BT_ON" \
+        icon.font="$NERD:Bold:16.0" \
         icon.color=$GREY \
         label.drawing=off \
         drawing=on
     fi
   else
-    # Bluetooth désactivé - icône rouge
     sketchybar --set bluetooth \
-      icon="$BLUETOOTH_OFF" \
+      icon="$BT_OFF" \
+      icon.font="$NERD:Bold:16.0" \
       icon.color=$RED \
       label.drawing=off \
       drawing=on

--- a/dot_config/sketchybar/plugins/bluetooth/executable_item.sh
+++ b/dot_config/sketchybar/plugins/bluetooth/executable_item.sh
@@ -3,26 +3,27 @@ source "$HOME/.config/sketchybar/settings/settings.sh"
 source "$SETTINGS_DIR/colors.sh"
 source "$SETTINGS_DIR/icons.sh"
 
-# Module Bluetooth simplifié
+# -- Claude Dark theme (Zed port style) --
+# Active/connected: $ORANGE accent
+# Idle/no devices: $GREY muted
+# Disabled: $RED semantic
+
 bluetooth=(
   script="$PLUGIN_DIR/bluetooth/bluetooth.sh"
-  update_freq=5
+  update_freq=30
 
-  # Icon
-  icon="$BLUETOOTH"
-  icon.font="$FONT:Bold:14.0"
-  icon.color=$BLUE
+  icon="󰂯"
+  icon.font="Liga SFMono Nerd Font:Bold:16.0"
+  icon.color=$GREY
   icon.padding_left=$PADDINGS
   icon.padding_right=$PADDINGS
 
-  # Label (nombre d'appareils connectés)
   label.drawing=off
   label.font="$FONT:Semibold:11.0"
   label.color=$WHITE
   label.padding_left=$PADDINGS
   label.padding_right=$PADDINGS
 
-  # Background désactivé (dans le bracket status)
   background.drawing=off
 )
 

--- a/dot_config/sketchybar/plugins/github/executable_item.sh
+++ b/dot_config/sketchybar/plugins/github/executable_item.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-source "$HOME/.config/sketchybar/settings/settings.sh" # Loads all the settings
-source "$SETTINGS_DIR/colors.sh" # Loads all defined colors
-source "$SETTINGS_DIR/icons.sh" # Loads all defined icons
+source "$HOME/.config/sketchybar/settings/settings.sh"
+source "$SETTINGS_DIR/colors.sh"
+source "$SETTINGS_DIR/icons.sh"
+
+# -- Claude Dark theme (Zed port style) --
+# Bell icon: $GREY muted by default
+# Highlight (notifications): $ORANGE accent
 
 POPUP_CLICK_SCRIPT="sketchybar --set \$NAME popup.drawing=toggle"
 
@@ -9,10 +13,11 @@ github_bell=(
   update_freq=180
   icon.font="$FONT:Bold:15.0"
   icon=$BELL
-  icon.color=$BLUE
+  icon.color=$GREY
   label=$LOADING
-  label.highlight_color=$BLUE
-  popup.align=left
+  label.color=$WHITE
+  label.highlight_color=$ORANGE
+  popup.align=right
   script="$PLUGIN_DIR/github/github.sh"
   click_script="$POPUP_CLICK_SCRIPT"
 )

--- a/dot_config/sketchybar/plugins/wifi/executable_wifi.sh
+++ b/dot_config/sketchybar/plugins/wifi/executable_wifi.sh
@@ -3,10 +3,9 @@ source "$HOME/.config/sketchybar/settings/settings.sh" # Loads all the settings
 source "$SETTINGS_DIR/colors.sh" # Loads all defined colors
 source "$SETTINGS_DIR/icons.sh" # Loads all defined icons
 
-IS_VPN=$(/usr/local/bin/piactl get connectionstate)
-CURRENT_WIFI="$(ipconfig getsummary en0)"
-IP_ADDRESS="$(echo "$CURRENT_WIFI" | grep -o "yiaddr = .*" | sed 's/^yiaddr = //')"
-SSID="$(echo "$CURRENT_WIFI" | grep -o "SSID : .*" | sed 's/^SSID : //' | tail -n 1)"
+IS_VPN=$(/usr/local/bin/piactl get connectionstate 2>/dev/null)
+IP_ADDRESS="$(ipconfig getifaddr en0 2>/dev/null)"
+SSID="$(system_profiler SPAirPortDataType 2>/dev/null | awk '/Current Network Information:/{getline; gsub(/^[ \t]+|:$/,""); print; exit}')"
 
 if [[ $IS_VPN == "Connected" ]]; then
   ICON_COLOR=$GREEN

--- a/dot_config/sketchybar/settings/executable_icons.sh
+++ b/dot_config/sketchybar/settings/executable_icons.sh
@@ -68,7 +68,6 @@ IRECENT=􀐫
 
 # Airpods Icons
 AIRPODS=􁄡
-
 # Apple Device Icons
 IPHONE=􀟜
 IPAD=􀟠
@@ -89,5 +88,11 @@ MODE_VISUAL=􀂿
 MODE_CMD=􀂙
 MODE_PENDING=􀈏
 
+# aerospace modes
+AERO_NORMAL=􀂕
+AERO_RESIZE=􀂷
+AERO_SERVICE=􀂹
+
 # Theme
 THEME=􀎔
+

--- a/dot_config/svim/blacklist
+++ b/dot_config/svim/blacklist
@@ -1,0 +1,11 @@
+Ghostty
+Alacritty
+iTerm2
+Kitty
+Terminal
+MacVim
+Neovide
+WezTerm
+Zed
+Zed Preview
+Code

--- a/dot_config/svim/executable_svim.sh
+++ b/dot_config/svim/executable_svim.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Hook appele par svim a chaque changement de mode ou de commandline
+# Variables disponibles: $MODE et $CMDLINE
+
+sketchybar --trigger svim_update MODE="$MODE" CMDLINE="$CMDLINE"

--- a/dot_config/svim/svimrc
+++ b/dot_config/svim/svimrc
@@ -1,0 +1,3 @@
+nmap Y y$
+nmap H ^
+nmap L $


### PR DESCRIPTION
## Resume

- Ajout du dual input mode AeroSpace (leader key F18 + held modifier ctrl+alt)
- Nouvelle regle Karabiner Right Option -> F18 pour leader key
- Fix modules Sketchybar (bluetooth, wifi, github, mode indicator)
- Ajout config SketchyVim
- Ajout GitHub templates et CONTRIBUTING.md

Closes #11

## Configs modifiees

- [x] aerospace
- [x] sketchybar
- [x] karabiner
- [ ] zed
- [ ] ghostty
- [x] svim
- [ ] nix
- [ ] zsh
- [ ] tmux

## Changements

- **aerospace**: mode aero (F18 leader key), modes resize/service, triggers sketchybar sur tous les bindings
- **karabiner**: regle Right Option -> F18, fix ISO keyboard type (country_code 1)
- **sketchybar**: indicateur mode aero (SF Symbol icons A/R/S), bluetooth Nerd Font, wifi system_profiler, github popup align right, svim integration
- **svim**: blacklist, svimrc, hook sketchybar
- **docs**: README dual mode + svim, CONTRIBUTING.md, issue/PR templates

## Tests

- [x] `chezmoi diff` verifie
- [x] Config testee localement
- [x] Pas de regression sur les autres configs