### PR TITLE
feat(sketchybar, zed): storage module, RAM multi-graph, terminal keybindings

### DIFF
--- a/dot_config/sketchybar/executable_sketchybarrc
+++ b/dot_config/sketchybar/executable_sketchybarrc
@@ -108,6 +108,7 @@ sketchybar --add bracket status music_prev music_play music_next music nix brew 
              background.border_width=1
 
 source "$PLUGIN_DIR/codexbar.sh"
+source "$PLUGIN_DIR/storage.sh"
 source "$PLUGIN_DIR/ram.sh"
 source "$PLUGIN_DIR/cpu.sh"
 

--- a/dot_config/sketchybar/plugins/executable_ram.sh
+++ b/dot_config/sketchybar/plugins/executable_ram.sh
@@ -2,8 +2,8 @@
 source "$HOME/.config/sketchybar/settings/settings.sh"
 source "$SETTINGS_DIR/colors.sh"
 
-# -- Claude Dark theme (Zed port style) --
-# Graph style matching CPU module
+# -- RAM module with 3 graphs: active, wired, compressed --
+# Same layout as CPU (sys/user)
 
 ram_top=(
   label.font="$FONT:Semibold:7"
@@ -29,7 +29,29 @@ ram_percent=(
   updates=on
 )
 
-ram_graph=(
+ram_compressed=(
+  width=0
+  graph.color=$BLUE
+  graph.fill_color=$BLUE
+  label.drawing=off
+  icon.drawing=off
+  background.height=20
+  background.drawing=on
+  background.color=$TRANSPARENT
+)
+
+ram_wired=(
+  width=0
+  graph.color=$ORANGE
+  graph.fill_color=$ORANGE
+  label.drawing=off
+  icon.drawing=off
+  background.height=20
+  background.drawing=on
+  background.color=$TRANSPARENT
+)
+
+ram_active=(
   graph.color=$MAGENTA
   graph.fill_color=$MAGENTA
   label.drawing=off
@@ -39,11 +61,17 @@ ram_graph=(
   background.color=$TRANSPARENT
 )
 
-sketchybar --add item ram.top right               \
-           --set ram.top "${ram_top[@]}"           \
-                                                   \
-           --add item ram.percent right            \
-           --set ram.percent "${ram_percent[@]}"   \
-                                                   \
-           --add graph ram.graph right 35          \
-           --set ram.graph "${ram_graph[@]}"
+sketchybar --add item ram.top right                    \
+           --set ram.top "${ram_top[@]}"                \
+                                                        \
+           --add item ram.percent right                 \
+           --set ram.percent "${ram_percent[@]}"        \
+                                                        \
+           --add graph ram.compressed right 50          \
+           --set ram.compressed "${ram_compressed[@]}"  \
+                                                        \
+           --add graph ram.wired right 50               \
+           --set ram.wired "${ram_wired[@]}"            \
+                                                        \
+           --add graph ram.active right 50              \
+           --set ram.active "${ram_active[@]}"

--- a/dot_config/sketchybar/plugins/executable_ram_usage.sh
+++ b/dot_config/sketchybar/plugins/executable_ram_usage.sh
@@ -16,15 +16,18 @@ USED_PAGES=$(( ${PAGES_ACTIVE:-0} + ${PAGES_WIRED:-0} + ${PAGES_COMPRESSED:-0} )
 PCT=$((USED_PAGES * 100 / TOTAL_PAGES))
 [ "$PCT" -gt 100 ] && PCT=100
 
-# Normalized value for graph (0.0 - 1.0)
-GRAPH_VAL=$(awk "BEGIN { printf \"%.2f\", $PCT / 100 }")
+# Normalized values per category (0.0 - 1.0)
+ACTIVE_VAL=$(awk "BEGIN { printf \"%.2f\", ${PAGES_ACTIVE:-0} / $TOTAL_PAGES }")
+WIRED_VAL=$(awk "BEGIN { printf \"%.2f\", ${PAGES_WIRED:-0} / $TOTAL_PAGES }")
+COMPRESSED_VAL=$(awk "BEGIN { printf \"%.2f\", ${PAGES_COMPRESSED:-0} / $TOTAL_PAGES }")
 
-# Color based on usage level
+# Color for percentage label
 if   [ "$PCT" -le 60 ]; then COLOR=$MAGENTA
 elif [ "$PCT" -le 80 ]; then COLOR=$ORANGE
 else                         COLOR=$RED
 fi
 
 sketchybar --set ram.percent label="${PCT}%" \
-           --set ram.graph graph.color="$COLOR" graph.fill_color="$COLOR" \
-           --push ram.graph "$GRAPH_VAL"
+           --push ram.active "$ACTIVE_VAL" \
+           --push ram.wired "$WIRED_VAL" \
+           --push ram.compressed "$COMPRESSED_VAL"

--- a/dot_config/sketchybar/plugins/executable_storage.sh
+++ b/dot_config/sketchybar/plugins/executable_storage.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+source "$HOME/.config/sketchybar/settings/settings.sh"
+source "$SETTINGS_DIR/colors.sh"
+
+# -- Storage module (battery-style bar) --
+
+storage_top=(
+  label.font="$FONT:Semibold:7"
+  label=SSD
+  label.color=$GREY
+  icon.drawing=off
+  width=0
+  padding_right=10
+  y_offset=6
+)
+
+storage_usage=(
+  label.font="$FONT:Heavy:10"
+  label="0/0"
+  label.color=$WHITE
+  y_offset=-4
+  padding_left=0
+  padding_right=10
+  width=65
+  icon.drawing=off
+  script="$PLUGIN_DIR/storage_usage.sh"
+  update_freq=300
+  updates=on
+)
+
+storage_bar=(
+  label.font="$FONT:Black:12"
+  label="▁"
+  label.color=$BLUE
+  icon.drawing=off
+  y_offset=-4
+  padding_left=0
+  padding_right=8
+  width=25
+)
+
+sketchybar --add item storage.top right               \
+           --set storage.top "${storage_top[@]}"       \
+                                                       \
+           --add item storage.usage right              \
+           --set storage.usage "${storage_usage[@]}"   \
+                                                       \
+           --add item storage.bar right                \
+           --set storage.bar "${storage_bar[@]}"

--- a/dot_config/sketchybar/plugins/executable_storage_usage.sh
+++ b/dot_config/sketchybar/plugins/executable_storage_usage.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+source "$HOME/.config/sketchybar/settings/colors.sh"
+
+# Get real APFS container usage (df lies on APFS snapshots)
+CONTAINER_INFO=$(diskutil apfs list 2>/dev/null | grep -A5 "Container disk3")
+TOTAL_BYTES=$(echo "$CONTAINER_INFO" | awk '/Size \(Capacity Ceiling\)/{print $4}')
+USED_BYTES=$(echo "$CONTAINER_INFO" | awk '/Capacity In Use By Volumes/{print $6}')
+
+# Convert bytes to human readable (GB)
+USED_GB=$(awk "BEGIN { printf \"%.0f\", $USED_BYTES / 1000000000 }")
+TOTAL_GB=$(awk "BEGIN { printf \"%.0f\", $TOTAL_BYTES / 1000000000 }")
+
+# Calculate percentage
+PCT=$(awk "BEGIN { printf \"%.0f\", $USED_BYTES * 100 / $TOTAL_BYTES }")
+
+# Color based on usage level
+if   [ "$PCT" -le 60 ]; then COLOR=$BLUE
+elif [ "$PCT" -le 80 ]; then COLOR=$ORANGE
+else                         COLOR=$RED
+fi
+
+# Vertical battery gauge (single block character, fills from bottom)
+if   [ "$PCT" -le 12 ]; then BAR="▁"
+elif [ "$PCT" -le 25 ]; then BAR="▂"
+elif [ "$PCT" -le 37 ]; then BAR="▃"
+elif [ "$PCT" -le 50 ]; then BAR="▄"
+elif [ "$PCT" -le 62 ]; then BAR="▅"
+elif [ "$PCT" -le 75 ]; then BAR="▆"
+elif [ "$PCT" -le 87 ]; then BAR="▇"
+else                         BAR="█"
+fi
+
+sketchybar --set storage.usage label="${USED_GB}G/${TOTAL_GB}G" label.color="$COLOR" \
+           --set storage.bar label="$BAR" label.color="$COLOR"

--- a/dot_config/zed/private_keymap.json
+++ b/dot_config/zed/private_keymap.json
@@ -125,7 +125,7 @@
       "ctrl-b": "pane::ActivatePreviousItem",
       "ctrl-x": "pane::CloseActiveItem",
       "ctrl-v": "pane::SplitRight",
-      "ctrl-s": "pane::SplitDown",
+      // "ctrl-s": "pane::SplitDown",
       
       // ── AI ────────────────────────────────────────────────────────────────
       "cmd-i": "assistant::InlineAssist",
@@ -150,95 +150,97 @@
       "alt-p": ["task::Spawn", { "task_name": "Files: Generate Project Structure file" }],
     },
   },
-  // {
-  //   "context": "Terminal && Vimode && !menu",
-  //   "bindings": {
-  //     // ── AI ──────────────────────────────────────────────────────────────────
-  //     "space i": "assistant::InlineAssist",
-  //     "space a i": "assistant::InlineAssist",
-  //     "space a f": "agent::ToggleFocus",
-  //     "space a p": "agent::AddSelectionToThread",
+  {
+    "context": "Terminal && !menu",
+    "bindings": {
+      // ── AI ──────────────────────────────────────────────────────────────────
+      "ctrl-a i": "assistant::InlineAssist",
+      "ctrl-a a i": "assistant::InlineAssist",
+      "ctrl-a a f": "agent::ToggleFocus",
+      "ctrl-a a p": "agent::AddSelectionToThread",
 
-  //     // ── Explorer ───────────────────────────────────────────────────────────
-  //     "space e": "project_panel::ToggleFocus",
-  //     "space space": "file_finder::Toggle",
+      // ── Explorer ───────────────────────────────────────────────────────────
+      "ctrl-a e": "project_panel::ToggleFocus",
+      "ctrl-a space": "file_finder::Toggle",
 
-  //     // ── Find / Search (space f) ────────────────────────────────────────────
-  //     "space f f": "file_finder::Toggle",
-  //     "space f g": "pane::DeploySearch",
-  //     "space f p": "projects::OpenRecent",
-  //     "space f s": "outline::Toggle",
-  //     "space f t": "terminal_panel::ToggleFocus",
-  //     "space f T": "workspace::NewCenterTerminal",
-  //     "space ;": "go_to_line::Toggle",
+      // ── Find / Search (space f) ────────────────────────────────────────────
+      "ctrl-a f f": "file_finder::Toggle",
+      "ctrl-a f g": "pane::DeploySearch",
+      "ctrl-a f p": "projects::OpenRecent",
+      "ctrl-a f s": "outline::Toggle",
+      "ctrl-a f t": "terminal_panel::ToggleFocus",
+      "ctrl-a f T": "workspace::NewCenterTerminal",
+      "ctrl-a e ;": "go_to_line::Toggle",
 
-  //     // ── Buffer (space b) ───────────────────────────────────────────────────
-  //     "space b n": "pane::ActivateNextItem",
-  //     "space b b": "pane::ActivatePreviousItem",
-  //     "space b d": "pane::CloseActiveItem",
-  //     "space b o": "pane::CloseOtherItems",
-  //     "space tab": "pane::ActivateNextItem",
-  //     "space shift-tab": "pane::ActivatePreviousItem",
-  //     "space v": "pane::SplitRight",
-  //     "space s": "pane::SplitDown",
-  //     "space x": "pane::CloseActiveItem",
+      // ── Buffer (space b) ───────────────────────────────────────────────────
+      "ctrl-a b n": "pane::ActivateNextItem",
+      "ctrl-a n": "pane::ActivateNextItem",
+      "ctrl-a b b": "pane::ActivatePreviousItem",
+      "ctrl-a b": "pane::ActivatePreviousItem",
+      "ctrl-a b d": "pane::CloseActiveItem",
+      "ctrl-a b o": "pane::CloseOtherItems",
+      "ctrl-a tab": "pane::ActivateNextItem",
+      "ctrl-a shift-tab": "pane::ActivatePreviousItem",
+      "ctrl-a v": "pane::SplitRight",
+      "ctrl-a s": "pane::SplitDown",
+      "ctrl-a x": "pane::CloseActiveItem",
 
-  //     // ── Window / Split (space w) ───────────────────────────────────────────
-  //     "space w v": "pane::SplitRight",
-  //     "space w s": "pane::SplitDown",
-  //     "space w d": "pane::CloseActiveItem",
-  //     "space w h": "workspace::ActivatePaneLeft",
-  //     "space w j": "workspace::ActivatePaneDown",
-  //     "space w k": "workspace::ActivatePaneUp",
-  //     "space w l": "workspace::ActivatePaneRight",
-  //     "space w n": "workspace::ActivateNextPane",
-  //     "space w b": "workspace::ActivatePreviousPane",
+      // ── Window / Split (space w) ───────────────────────────────────────────
+      "ctrl-a w v": "pane::SplitRight",
+      "ctrl-a w s": "pane::SplitDown",
+      "ctrl-a w d": "pane::CloseActiveItem",
+      "ctrl-a w h": "workspace::ActivatePaneLeft",
+      "ctrl-a w j": "workspace::ActivatePaneDown",
+      "ctrl-a w k": "workspace::ActivatePaneUp",
+      "ctrl-a w l": "workspace::ActivatePaneRight",
+      "ctrl-a w n": "workspace::ActivateNextPane",
+      "ctrl-a w b": "workspace::ActivatePreviousPane",
 
-  //     // ── Git (space g) ──────────────────────────────────────────────────────
-  //     "space g g": "git_panel::ToggleFocus",
-  //     "space G G": ["task::Spawn", { "task_name": "Git: Lazygit" }],
+      // ── Git (space g) ──────────────────────────────────────────────────────
+      "ctrl-a g g": "git_panel::ToggleFocus",
+      "ctrl-a G G": ["task::Spawn", { "task_name": "Git: Lazygit" }],
 
-  //     // ── Terminal (space t) ─────────────────────────────────────────────────
-  //     "space t t": "task::Spawn",
-  //     "space t T": "terminal::RerunTask",
+      // ── Terminal (space t) ─────────────────────────────────────────────────
+      "ctrl-a t t": "task::Spawn",
+      "ctrl-a t T": "terminal::RerunTask",
 
-  //     // ── Tools / Tasks (space t) ────────────────────────────────────────────
-  //     "space t n": ["task::Spawn", { "task_name": "IDE: Neovim" }],
-  //     "space t f": ["task::Spawn", { "task_name": "Files: FZF" }],
-  //     "space t y": ["task::Spawn", { "task_name": "Files: Yazi" }],
-  //     "space t r": ["task::Spawn", { "task_name": "Files: Rename Files (FZF)" }],
-  //     "space t d": ["task::Spawn", { "task_name": "Docker: Lazydocker" }],
-  //     "space t k": ["task::Spawn", { "task_name": "Kubernetes: Lazykube" }],
-  //     "space t p": ["task::Spawn", { "task_name": "Files: Generate Project Structure file" }],
-  //     "space t l": ["task::Spawn", { "task_name": "Git: Generate Git Logs file" }],
-  //     "space t L": ["task::Spawn", { "task_name": "Git: Generate Git Logs file (All)" }],
-  //     "space t s": ["task::Spawn", { "task_name": "LazySQL" }],
-  //     "space t S": ["task::Spawn", { "task_name": "LazySSH" }],
-  //     "space t c": ["task::Spawn", { "task_name": "LazyCurl" }],
-  //     "space t m": ["task::Spawn", { "task_name": "Lazymake" }],
+      // ── Tools / Tasks (space t) ────────────────────────────────────────────
+      "ctrl-a t n": ["task::Spawn", { "task_name": "IDE: Neovim" }],
+      "ctrl-a t f": ["task::Spawn", { "task_name": "Files: FZF" }],
+      "ctrl-a t y": ["task::Spawn", { "task_name": "Files: Yazi" }],
+      "ctrl-a t r": ["task::Spawn", { "task_name": "Files: Rename Files (FZF)" }],
+      "ctrl-a t d": ["task::Spawn", { "task_name": "Docker: Lazydocker" }],
+      "ctrl-a t k": ["task::Spawn", { "task_name": "Kubernetes: Lazykube" }],
+      "ctrl-a t p": ["task::Spawn", { "task_name": "Files: Generate Project Structure file" }],
+      "ctrl-a t l": ["task::Spawn", { "task_name": "Git: Generate Git Logs file" }],
+      "ctrl-a t L": ["task::Spawn", { "task_name": "Git: Generate Git Logs file (All)" }],
+      "ctrl-a t s": ["task::Spawn", { "task_name": "LazySQL" }],
+      "ctrl-a t S": ["task::Spawn", { "task_name": "LazySSH" }],
+      "ctrl-a t c": ["task::Spawn", { "task_name": "LazyCurl" }],
+      "ctrl-a t m": ["task::Spawn", { "task_name": "Lazymake" }],
 
-  //     // ── AI (space a) ──────────────────────────────────────────────────────
-  //     "space a c": ["task::Spawn", { "task_name": "Claude Code" }],
-  //     "space a C": ["task::Spawn", { "task_name": "Claude Code (Continue)" }],
-  //     "space a s": ["task::Spawn", { "task_name": "Claude Code (Dangerous Skip Permissions)" }],
-  //     "space a S": [
-  //       "task::Spawn",
-  //       { "task_name": "Claude Code (Continue + Dangerous Skip Permissions)" },
-  //     ],
-  //     "space a b": ["task::Spawn", { "task_name": "Claude Code (Chrome)" }],
-  //     "space a B": ["task::Spawn", { "task_name": "Claude Code (Continue + Chrome)" }],
+      // ── AI (space a) ──────────────────────────────────────────────────────
+      "ctrl-a a c": ["task::Spawn", { "task_name": "Claude Code" }],
+      "ctrl-a a C": ["task::Spawn", { "task_name": "Claude Code (Continue)" }],
+      "ctrl-a a s": ["task::Spawn", { "task_name": "Claude Code (Dangerous Skip Permissions)" }],
+      "ctrl-a a S": [
+        "task::Spawn",
+        { "task_name": "Claude Code (Continue + Dangerous Skip Permissions)" },
+      ],
+      "ctrl-a a b": ["task::Spawn", { "task_name": "Claude Code (Chrome)" }],
+      "ctrl-a a B": ["task::Spawn", { "task_name": "Claude Code (Continue + Chrome)" }],
 
-  //     // ── Settings (space ,) ─────────────────────────────────────────────────
-  //     "space , k": "zed::OpenKeymapFile",
-  //     "space , K": "zed::OpenKeymap",
-  //     "space , s": "zed::OpenSettingsFile",
-  //     "space , S": "zed::OpenSettings",
-  //     "space , t": "zed::OpenTasks",
-  //     "space , c": "theme_selector::Toggle",
-  //     "space , C": "icon_theme_selector::Toggle",
-  //     "space , e": "zed::Extensions",
-  //   },
-  // },
+      // ── Settings (space ,) ─────────────────────────────────────────────────
+      "ctrl-a , k": "zed::OpenKeymapFile",
+      "ctrl-a , K": "zed::OpenKeymap",
+      "ctrl-a , s": "zed::OpenSettingsFile",
+      "ctrl-a , S": "zed::OpenSettings",
+      "ctrl-a , t": "zed::OpenTasks",
+      "ctrl-a , c": "theme_selector::Toggle",
+      "ctrl-a , C": "icon_theme_selector::Toggle",
+      "ctrl-a , e": "zed::Extensions",
+    },
+  },
   // ════════════════════════════════════════════════════════════════════════════
   // Editor (all modes, consolidated)
   // ════════════════════════════════════════════════════════════════════════════
@@ -384,7 +386,7 @@
       "space t s": ["task::Spawn", { "task_name": "LazySQL" }],
       "space t S": ["task::Spawn", { "task_name": "LazySSH" }],
       "space t c": ["task::Spawn", { "task_name": "LazyCurl" }],
-      "space t e": ["task::Spawn", { "task_name": "Documentaion: Ekphos" }],
+      "space t ": ["task::Spawn", { "task_name": "Documentaion: Ekphos" }],
       "space t E": ["task::Spawn", { "task_name": "Documentaion: Ekphos file (FZF)" }],
       "space t m": ["task::Spawn", { "task_name": "Lazymake" }],
 

--- a/dot_config/zed/private_settings.json
+++ b/dot_config/zed/private_settings.json
@@ -15,7 +15,7 @@
   "experimental.theme_overrides": {
     "background.appearance": "blurred",
   },
-  "redact_private_values": true,
+  "redact_private_values": false,
   "current_line_highlight": "all",
   "bottom_dock_layout": "contained",
 


### PR DESCRIPTION
## Resume

Sync des configs sketchybar et zed avec les modifications locales : nouveau module stockage, amélioration du graphe RAM, et activation des keybindings terminal Zed.

## Configs modifiees

- [ ] aerospace
- [x] sketchybar
- [ ] karabiner
- [x] zed
- [ ] ghostty
- [ ] svim
- [ ] nix
- [ ] zsh
- [ ] tmux

## Changements

### sketchybar
- Nouveau module stockage avec jauge verticale style batterie (unicode ▁▂▃▄▅▆▇█)
- Utilisation de `diskutil apfs list` pour les vraies valeurs APFS (au lieu de `df` qui ment sur les snapshots)
- Affichage `<utilisé>G/<total>G` avec couleur dynamique (bleu/orange/rouge selon usage)
- Module RAM amélioré avec 3 courbes superposées : active (magenta), wired (orange), compressed (bleu)
- 50 points de données par graphe RAM (au lieu de 35)

### zed
- Activation des keybindings terminal (étaient commentés)
- Changement du prefix `space` → `ctrl-a` pour éviter les conflits vim
- Ajout raccourcis buffer : `ctrl-a n` (next) / `ctrl-a b` (previous)
- `redact_private_values` passé à false

## Tests

- [x] `chezmoi diff` verifie
- [x] `chezmoi apply --dry-run` sans erreur
- [x] Config testee localement
- [ ] Pas de regression sur les autres configs

## Issues

Closes #13, Closes #14, Closes #15